### PR TITLE
Skip rendering

### DIFF
--- a/src/cli/create/create.js
+++ b/src/cli/create/create.js
@@ -27,7 +27,6 @@ export default function create(program) {
           outputRoot: '',
         });
 
-        console.log(generatedTemplate);
         writeTemplate(generatedTemplate, outputRoot);
       } catch (e) {
         log.info(e);

--- a/src/cli/create/create.js
+++ b/src/cli/create/create.js
@@ -27,6 +27,7 @@ export default function create(program) {
           outputRoot: '',
         });
 
+        console.log(generatedTemplate);
         writeTemplate(generatedTemplate, outputRoot);
       } catch (e) {
         log.info(e);

--- a/src/configs/loadCytoConfig/loadCytoConfig.js
+++ b/src/configs/loadCytoConfig/loadCytoConfig.js
@@ -19,9 +19,10 @@ import types from '../../utils/types';
  * and return a merged version of the 2 configs.
  *
  * Whe Cyto configs are loaded, all string dependencies are converted to
- * arrays with 2 values:
+ * arrays with 3 values:
  *   1. fileName - The original string with the file
  *   2. templateId - The template that the file comes from
+ *   3. skipRendering - Should we skip the rendering process for this file?
  * We do this to ensure we load the correct dependency files when configs are
  * merged. We can allow also store more information in the future if needed
  *
@@ -51,7 +52,7 @@ export default function loadCytoConfig(templateId) {
     ...rawConfig.dependencies.filter((d) => !types.isString(d)),
     ...rawConfig.dependencies
       .filter((d) => types.isString(d))
-      .map((d) => [d, rawConfig.templateId]),
+      .map((d) => [d, rawConfig.templateId, false]),
   ];
 
   return rawConfig.base

--- a/src/configs/loadCytoConfig/loadCytoConfig.test.js
+++ b/src/configs/loadCytoConfig/loadCytoConfig.test.js
@@ -13,6 +13,10 @@ describe('loadCytoConfig', () => {
 
   });
 
+  it('converts all string dependencies to arrays', () => {
+
+  });
+
   it('ensures the template is valid by calling validateTemplate', () => {
 
   });

--- a/src/dependencies/getRuntimeDependencies/getRuntimeDependencies.js
+++ b/src/dependencies/getRuntimeDependencies/getRuntimeDependencies.js
@@ -9,7 +9,8 @@ import types from '../../utils/types';
 
 /**
  * Generates a new set of dependencies after applying each dependency that's a
- * function.
+ * function. For string dependencies, a 3rd element is added to the array that
+ * indicates that the filename should not be rendered by mustache
  *
  * @param {Object} cytoConfig - The config file with the dependencies
  * @param {Object} args - The arguments to pass to each functional dependency
@@ -18,7 +19,7 @@ export default function getRuntimeDependencies(cytoConfig, args) {
   const { templateId, dependencies } = cytoConfig;
   const formatDep = (dep) => {
     return types.isString(dep)
-      ? [dep, templateId]
+      ? [dep, templateId, true]
       : dep;
   };
 

--- a/src/dependencies/renderDependency/renderDependency.js
+++ b/src/dependencies/renderDependency/renderDependency.js
@@ -19,11 +19,13 @@ import renderString from '../../utils/render/renderString';
  * @param {Object} args - Args for the renderer to use
  */
 export default async function renderDependency(dep, outputRoot, args) {
-  const [name, templateId] = dep;
-  const outputPath = await renderString(
-    path.join(outputRoot, name),
-    args,
-  );
+  const [name, templateId, skipRendering] = dep;
+  const outputPath = !skipRendering
+   ? await renderString(
+      path.join(outputRoot, name),
+      args,
+    )
+   : path.join(outputRoot, name);
 
   const template = loadTemplate(templateId);
   const contents = template[name]

--- a/src/utils/mustache.js
+++ b/src/utils/mustache.js
@@ -518,8 +518,6 @@ import chalk from 'chalk';
 
       if (value !== undefined)
         buffer += value;
-
-      console.log(buffer);
     }
 
     return buffer;

--- a/src/utils/mustache.js
+++ b/src/utils/mustache.js
@@ -518,6 +518,8 @@ import chalk from 'chalk';
 
       if (value !== undefined)
         buffer += value;
+
+      console.log(buffer);
     }
 
     return buffer;
@@ -569,6 +571,7 @@ import chalk from 'chalk';
       const v = await this.renderTokens(token[4], context, partials, originalTemplate);
       buffer += v;
     }
+
     return buffer;
   };
 


### PR DESCRIPTION
Don't pass string dependencies generated from runtime dependencies through mustache. This is mainly to allow `cyto create` to generate dependency files with names like `{{id}}.js`