### PR TITLE
Partial

### DIFF
--- a/docs/gettingStarted.md
+++ b/docs/gettingStarted.md
@@ -2,12 +2,12 @@
 
 ## What is Cyto?
 
-Cyto is built around one concept: the generation of boilerplate from templates. Templates are like blueprints, they tell Cyto exactly what boilerplate to generate, what arguments to prompt the user for, and what special options to set. Generation is just the process of taking a template and creating the boilerplate it specifies. Generation can be broken down into this flow of events:
+Cyto is built around one concept: the generation of boilerplate from templates. Templates are like blueprints, they tell Cyto exactly what boilerplate to generate, what arguments to prompt the user for, and what special options to set. Generation is just the process of taking a template and creating the boilerplate it specifies. At a high level, template generation can be broken down into this flow of events:
 
 1. User indicates that they want to generate boilerplate from a template by running the `cyto gen` command
 2. Cyto loads the specified template from the user's Global Template Library (abbreviated GTL) and performs some validation checks
 3. Cyto prompts the user for the arguments specified by the template
-4. Cyto processes each dependency, which produces the boilerplate to write to the filesystem. This process includes embedding the argument values into the dependency files.
+4. Cyto processes each of the template's declared dependencies, creating the boilerplate to write to the filesystem.
 5. Cyto outputs the created boilerplate. Tada!
 
 This document will walk you through the structure of templates and what the generation process looks like in practice.
@@ -16,10 +16,12 @@ This document will walk you through the structure of templates and what the gene
 
 Cyto requires some initialization before it can be used. This is done by running the `cyto init` command. This will prompt you for 2 things:
 
-1. Your name
+1. Your full name
 1. Where to create your GTL. This is where all of your templates will be stored, so make sure you pick a location that's easily accessible and not prone to deletion.
 
-If your GTL ever gets removed or you want to change your name, you can just rerun `cyto init`.
+If your GTL ever gets removed or you want to change your name, you can just rerun `cyto init`. `cyto init` will also pre-populate your GTL with some example templates that will help demonstrate the features that Cyto offers. You can find them all underneath the `cyto` directory in your GTL. These templates will be referenced extensively throughout the documentation.
+
+**NOTE**: Do not delete any of the templates in the `cyto` directory of your GTL. Some of them are required for Cyto to function properly.
 
 ## Template Structure
 
@@ -54,7 +56,7 @@ Even at it's simplest, there's a decent amount of information to process here, s
 
 ## The cyto.config.js file
 
-The `cyto.config.js` file is the key piece of any template. It holds all the information Cyto needs to take a template and create its specified boilerplate. A `cyto.config.js` must be written in Javascript, but you'll only need to understand basic Javascript syntax to get started using them. The actual config for the template is an object exported by the `cyto.config.js` file. That object must contain, at minimum, four keys:
+The `cyto.config.js` file is the key piece of any template. It holds all the information Cyto needs to take a template and create its specified boilerplate. A `cyto.config.js` must be written in Javascript, but you'll only need to understand basic Javascript syntax to get started. The actual config for the template is an object exported by the `cyto.config.js` file. That object must contain, at minimum, four keys:
 
 1. `templateId`: A unique identifier that determines where Cyto will look for the template in the GTL. Each `templateId` must be of the format `<group>/<name>`, where `group` is a logical grouping for related templates and `name` is a more specific descriptor for that template within the group. This template is in the `cyto` group and has a name of `tutorial`.
 2. `dependencies`: An array that represents everything a template needs to be generated. Dependencies can be strings, objects, or functions (more on this later). In this template, we have one string dependency: `{{id}}.txt`. This means Cyto will look for a file called `{{id}}.txt` inside of the `cyto/tutorial` directory and output it when the template is generated.

--- a/docs/options.md
+++ b/docs/options.md
@@ -1,7 +1,8 @@
 # Options
 
-Up til now, we haven't talked about the `options` key and what values you can set there. This document serves as a reference for all of the different options that you can set for a Cyto template
+Up til now, we haven't talked about the `options` key and what values you can set there. This document serves as a reference for all of the different options that you can set for a Cyto template. All options are false by default.
 
-1. `createDirectory`: If set to `true`, the generated template will be stored within a new directory. The name of this directory will be whatever the `id` arg is set to
+1. `createDirectory` : If set to `true`, the generated template will be stored within a new directory. The name of this directory will be whatever the `id` arg is set to.
+2. `skipRuntimeRendering`: If set to `true`, any string dependencies that were created by a runtime dependency will not be passed through the Mustache renderer.
 
 Right now, there are extremely few options that you can set for Cyto. There will almost certainly be more to come.

--- a/docs/runtimeDependencies.md
+++ b/docs/runtimeDependencies.md
@@ -1,7 +1,7 @@
 # Runtime dependencies
 
 ## What are runtime dependencies?
-If you created your own Cyto template earlier, you'll remember that creating a new template is, under the hood, generating the `cyto/template` template. One of the arguments this template takes is a list argument called `files` , which creates an empty file for each value in the list. But how did the `cyto/template` template declare those file dependencies if it only knows what files it needs at generation time after the user has supplied the required args? The answer is runtime dependencies.
+If you created your own Cyto template earlier, you'll remember that creating a new template is, under the hood, generating the `cyto/template` template. One of the arguments this template takes is a list argument called `files` , which creates an empty file for each value in the list. But how did the `cyto/template` template declare those file dependencies if it only knows what files it needs after the user has supplied the required args? The answer is runtime dependencies.
 
 A runtime dependency is a function placed in the `dependencies` section of `cyto.config.js` that takes the args supplied to the template at generation time and returns a new set of dependencies. This set can be one of four things: a single string, a single object, a list of strings, or a list of objects.
 
@@ -13,9 +13,9 @@ module.exports = {
   templateId: "cyto/runtimeDependencies",
   dependencies: [
     // Case 1: Returns a string
-    (args) => '{{fileName}}.txt',
+    (args) => '{{id}}.txt',
     // Case 2: Returns an array of strings
-    (args) => ['{{fileName}}.txt', 'blank.txt'],
+    (args) => ['{{id}}.txt', 'blank.txt'],
     // Case 3: Returns an object
     (args) => {
       return {
@@ -32,14 +32,21 @@ module.exports = {
         {
           templateId: 'cyto/composed',
           args: {
-            id: 'unique',
+            id: 'nonUnique',
             templateArg: 'I came from case 4'
+          }
+        },
+        {
+          templateId: 'cyto/composed',
+          args: {
+            id: 'unique',
+            templateArg: 'I also came from case 4'
           }
         }
       ];
     },
-    // A more realistic use case, creates a new template for each value in
-    // args.templates
+    // Case 5: A more realistic use case, creates a new template for each value
+    // in args.templates
     (args) => {
       return args
         .templates
@@ -55,7 +62,6 @@ module.exports = {
     }
   ],
   args: [
-    { id: 'fileName' },
     {
       id: 'templates',
       type: 'list',
@@ -64,58 +70,18 @@ module.exports = {
   ],
   options: {
     createDirectory: false,
+    skipRuntimeRendering: false,
   }
 };
 ```
 
-As you can see, a runtime dependency is just a function that takes a single parameter `args`.  This template demonstrates two important things: what the return types for a runtime dependency are and how dependencies are uniqued. If these dependencies weren't uniqued, we'd end up with a new set of dependencies that looks like this:
-
-```js
-[
-  '{{fileName}}.txt',
-  '{{fileName}}.txt',
-  'blank.txt',
-  {
-    templateId: 'cyto/composed',
-    args: {
-      id: 'nonUnique',
-      templateArg: 'I came from case 3'
-    }
-  },
-  {
-    templateId: 'cyto/composed',
-    args: {
-      id: 'nonUnique',
-      templateArg: 'I came from case 4'
-    }
-  },
-]
-```
-
-```bash
-> cyto gen cyto/runtimeDependencies demo
-Generating cyto/runtimeDependencies with id demo
-? fileName:  example
-? templates:  foo,bar
-Generating cyto/tutorial with id nonUnique
-Generating cyto/composed with id unique
-? userArg:  Some cool string
-Generating cyto/composed with id foo
-? userArg:  Another cool string
-Generating cyto/composed with id bar
-? userArg:  A lame string... :(
-> ls
-blank.txt bar.txt       example.txt   foo.txt       nonUnique.txt unique.txt
-```
-
 ## The args parameter
 
-As you can see, a runtime dependency is just a function that takes a single parameter `args`, which is an object that maps argument ids to supplied values. If we were to log out what `args` was, assuming we ran `cyto gen cyto/runtimeDependencies demo` and provided the values `test` and `foo,bar` for the `fileName` and `templates` args respectively, it would look like this:
+As you can see, a runtime dependency is just a function that takes a single parameter `args`, which is an object that maps argument ids to supplied values. If we were to log what `args` was, assuming we ran `cyto gen cyto/runtimeDependencies demo` and provided the value `foo,bar` for the `templates` argument, it would look like this:
 ```js
 {
   id: 'demo',
   author: 'Connor Taylor',
-  fileName: 'test',
   templates: [
     { id: 'foo' },
     { id: 'bar' }
@@ -123,15 +89,64 @@ As you can see, a runtime dependency is just a function that takes a single para
 }
 ```
 
-The `args` object is a mapping of argument ids to supplied values and is also what is passed as context for the mustache renderer. One important thing to note is that list args are not arrays of strings but rather arrays of objects. This is because mustache [sections](http://mustache.github.io/mustache.5.html#Sections) require arrays of objects, not strings. Cyto converts each string to an object with the string stored under the `id` key.
+The `args` object is a mapping of argument ids to supplied values. Each key is the `id` of the argument and the value is whatever the user supplied. The `args` object is also what is passed to the Mustache renderer when file dependencies are processed.
 
-## How to use runtime dependencies
-In this template, all the runtime dependency does is [map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) over the `args.files` array and returns a new array containing just the ids. This return value is merged into the existing set of dependencies automatically. Assuming that we had a set of args like the one above, the final set of dependencies would look like this:
+One important thing to note is that list args are not arrays of strings but rather arrays of objects. This is because Mustache [sections](http://mustache.github.io/mustache.5.html#Sections) require arrays of objects, not strings. To avoid this issue, Cyto converts each string to an object with the string stored under the `id` key. If your section requires more values than `id`, consider making a Cyto partial for the contents.
 
-```js
-[
-  '{{name}}.js',
-  'foo.txt',
-  '{{id}}.js'
-]
+## Uniquing runtime dependencies
+
+Now that we understand how runtime dependencies are structured, let's see what the generated `cyto/runtimeDependencies` template looks like:
+
+```bash
+cyto gen cyto/runtimeDependencies demo
+Generating cyto/runtimeDependencies with id demo
+? templates:  foo,bar
+Generating cyto/composed with id nonUnique
+? userArg:  test1
+Generating cyto/composed with id unique
+? userArg:  test2
+Generating cyto/composed with id foo
+? userArg:  test3
+Generating cyto/composed with id bar
+? userArg:  test4
+> ls
+bar.txt       blank.txt     demo.txt      foo.txt       nonUnique.txt unique.txt
 ```
+
+Let's break down how each of these files was created:
+
+1. `bar.txt`: From case 5 when we created a new object dependency for each item in the `templates` arg
+2. `blank.txt`: From case 2.
+3. `demo.txt`: From case 2. Case 2 provided an `{{id}}.txt` dependency, which was passed through the Mustache renderer with the set of arguments we showed above. Since `id` was set to `demo`, the generated dependency file was called `demo.txt`. Note that case 1 also provided an `{{id}}.txt`. Cyto uniques runtime dependencies, preferring the output of runtime dependencies closer to the end of the list. Since case 2 provided a duplicate `{{id}}.txt`, it used that one since case 2 comes after case 1.
+4. `foo.txt`: Same as `bar.txt`
+5. `nonUnique.txt`: From case 4. Again, Cyto uniques runtime dependencies. For object dependencies, it uses the `id` key to unique them. Since case 3 and case 4 both provided an object dependency with an id of `nonUnique`, Cyto used the one from case 4 because it was provided after case 3. This can be proven by looking at the contents of `nonUnique.txt`:
+```bash
+> cat nonUnique.txt
+cyto/composed was generated by another template and given an id of: nonUnique
+
+This template was given a userArg value of: test1
+
+The parent template supplied this value: I came from case 4
+```
+6. `unique.txt`: From case 4.
+
+## The skipRuntimeRendering option
+
+You'll notice that there's an option in this template that we haven't seen yet: `skipRuntimeRendering`. This is a special option that will prevent string dependencies created through a runtime dependency from being rendered by Mustache. If we set this option to true and provided the same arguments as we did before, we'd get the following set of files:
+
+```bash
+> ls
+bar.txt       blank.txt     foo.txt       nonUnique.txt unique.txt    {{id}}.txt
+```
+
+We get almost the exact same set of files, but `demo.txt` has been replaced with `{{id}}.txt`. This is because we didn't pass the `{{id}}.txt` file through the Mustache renderer, so the name never changed like it did before. The default value for `skipRuntimeRendering` is false, meaning that runtime dependencies are rendered by default. This option provides a way to bypass that functionality if desired, although it's often not necessary. The best example of where this is necessary is in the `cyto/template` template. Since a desired output file may very well be something like `{{id}}.txt`, `cyto/template` sets `skipRuntimeRendering` to true.
+
+## When to use runtime dependencies
+
+Runtime dependencies are provided as a catch-all for generating boilerplate in ways not directly handled by the core Cyto API. Some examples of this are:
+
+1. Rendering a set of templates based on some user input, as we did in case 5 in the example above.
+2. Supplying a dependency only if a certain argument was set to true
+3. Overwriting a base template's dependency
+
+There are many other ways to use runtime dependencies as well. Keep an open mind and you'll be sure to find a good use case runtime dependencies!

--- a/src/args/getArgsForTemplate/getArgsForTemplate.js
+++ b/src/args/getArgsForTemplate/getArgsForTemplate.js
@@ -29,8 +29,13 @@ export default async function getArgsForTemplate(cytoConfig, args) {
     return { ...accum, ...parsedValue };
   };
 
+  const baseArgs = cytoConfig.base
+    ? cytoConfig.base.args
+    : {};
+
   return synchReduce(cytoConfig.args, getArg, {
     ...args,
+    ...baseArgs,
     id: args.id,
     author: args.author,
   });

--- a/src/args/getArgsForTemplate/getArgsForTemplate.js
+++ b/src/args/getArgsForTemplate/getArgsForTemplate.js
@@ -29,7 +29,7 @@ export default async function getArgsForTemplate(cytoConfig, args) {
     return { ...accum, ...parsedValue };
   };
 
-  const baseArgs = cytoConfig.base
+  const baseArgs = cytoConfig.base && cytoConfig.base.args
     ? cytoConfig.base.args
     : {};
 

--- a/src/configs/loadCytoConfig/loadCytoConfig.js
+++ b/src/configs/loadCytoConfig/loadCytoConfig.js
@@ -56,6 +56,6 @@ export default function loadCytoConfig(templateId) {
   ];
 
   return rawConfig.base
-    ? mergeCytoConfigs(rawConfig, loadCytoConfig(rawConfig.base))
+    ? mergeCytoConfigs(rawConfig, loadCytoConfig(rawConfig.base.templateId))
     : rawConfig;
 }

--- a/src/configs/loadCytoConfig/loadCytoConfig.js
+++ b/src/configs/loadCytoConfig/loadCytoConfig.js
@@ -22,7 +22,7 @@ import types from '../../utils/types';
  * arrays with 3 values:
  *   1. fileName - The original string with the file
  *   2. templateId - The template that the file comes from
- *   3. skipRendering - Should we skip the rendering process for this file?
+ *   3. isRuntimeDep - Was this dependency created at runtime?
  * We do this to ensure we load the correct dependency files when configs are
  * merged. We can allow also store more information in the future if needed
  *

--- a/src/dependencies/renderDependency/renderDependency.js
+++ b/src/dependencies/renderDependency/renderDependency.js
@@ -18,16 +18,17 @@ import renderString from '../../utils/render/renderString';
  * @param {string} outputRoot - Where to write the rendered content
  * @param {Object} args - Args for the renderer to use
  */
-export default async function renderDependency(dep, outputRoot, args) {
-  const [name, templateId, skipRendering] = dep;
-  const outputPath = !skipRendering
-   ? await renderString(
+export default async function renderDependency(dep, outputRoot, args, options) {
+  const [name, templateId, isRuntimeDep] = dep;
+  const outputPath = isRuntimeDep && options.skipRuntimeRendering
+   ? path.join(outputRoot, name)
+   : await renderString(
       path.join(outputRoot, name),
       args,
-    )
-   : path.join(outputRoot, name);
+    );
 
   const template = loadTemplate(templateId);
+
   const contents = template[name]
     ? await renderString(template[name], args)
     : '';

--- a/src/template/generateTemplate/generateTemplate.js
+++ b/src/template/generateTemplate/generateTemplate.js
@@ -67,6 +67,7 @@ export default async function generateTemplate(options) {
       dep,
       outputRoot,
       templateArgs,
+      cytoConfig.options,
     );
 
     return { ...accum, ...renderedDep };

--- a/src/utils/mustache.js
+++ b/src/utils/mustache.js
@@ -180,7 +180,6 @@ import chalk from 'chalk';
 
       // Get the tag type.
       type = scanner.scan(tagRe) || 'name';
-      isPartial = type === '>';
       scanner.scan(whiteRe);
 
       // Get the tag value.
@@ -193,6 +192,14 @@ import chalk from 'chalk';
         scanner.scan(curlyRe);
         scanner.scanUntil(closingTagRe);
         type = '&';
+      } else if (type === '>') {
+        isPartial = true;
+        value = scanner.scanUntil(closingTagRe);
+        if (value.includes('{')) {
+          value += scanner.scan(closingTagRe);
+
+          value += scanner.scanUntil(closingTagRe);
+        }
       } else {
         value = scanner.scanUntil(closingTagRe);
       }

--- a/src/utils/render/renderString/renderString.js
+++ b/src/utils/render/renderString/renderString.js
@@ -11,12 +11,11 @@ import types from '../../types';
 import errors from '../../errors';
 
 /**
- * Description of renderString
- *
+ * Renders a string by passing it through the mustache renderer with the given
+ * arguments. Handles partials in a special way.
  */
-export default function renderString(str, args) {
+export default async function renderString(str, args) {
   mustache.escape = (text) => text; // Don't escape html
-
   const renderPartial = async (partialString, context) => {
     const tokens = partialString.split(' ').filter((s) => s.trim());
     if (!tokens.length || tokens.length > 2) {
@@ -29,7 +28,8 @@ export default function renderString(str, args) {
       }
     }
 
-    const [templateId, id] = tokens;
+    const [rawId, id] = tokens;
+    const templateId = await renderString(rawId, context);
     const cytoConfig = loadCytoConfig(templateId);
 
     if (!types.isPartial(cytoConfig)) {
@@ -47,5 +47,7 @@ export default function renderString(str, args) {
     }, '');
   };
 
-  return mustache.render(str, args, renderPartial);
+  const renderedString = await mustache.render(str, args, renderPartial);
+
+  return renderedString;
 }

--- a/src/utils/render/renderString/renderString.js
+++ b/src/utils/render/renderString/renderString.js
@@ -18,6 +18,7 @@ export default async function renderString(str, args) {
   mustache.escape = (text) => text; // Don't escape html
   const renderPartial = async (partialString, context) => {
     const tokens = partialString.split(' ').filter((s) => s.trim());
+    console.log(tokens);
     if (!tokens.length || tokens.length > 2) {
       errors.invalidPartial(partialString, '');
     } else if (tokens.length === 1) {

--- a/src/utils/render/renderString/renderString.js
+++ b/src/utils/render/renderString/renderString.js
@@ -18,7 +18,6 @@ export default async function renderString(str, args) {
   mustache.escape = (text) => text; // Don't escape html
   const renderPartial = async (partialString, context) => {
     const tokens = partialString.split(' ').filter((s) => s.trim());
-    console.log(tokens);
     if (!tokens.length || tokens.length > 2) {
       errors.invalidPartial(partialString, '');
     } else if (tokens.length === 1) {


### PR DESCRIPTION
1. Mustache partials can now use Mustache variables inside of their tag to render partials
1. `base` key for cyto.config.js files now expects an object (same format as object dependencies)
1.  Numerous small bug fixes